### PR TITLE
Setup cspi3 and spidev in DTS

### DIFF
--- a/arch/arm/boot/dts/imx6q-openrex.dts
+++ b/arch/arm/boot/dts/imx6q-openrex.dts
@@ -47,3 +47,12 @@
 &pcie {
 	status = "okay";
 };
+
+
+&ecspi3 {
+	spidev30: spi@3 {
+		compatible = "spidev";
+		reg = <0>;
+		spi-max-frequency = <57600000>;
+	};
+};

--- a/arch/arm/boot/dts/imx6qdl-openrex.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-openrex.dtsi
@@ -222,6 +222,14 @@
 	status = "okay";
 };
 
+&ecspi3 {
+	fsl,spi-num-chipselects = <2>;
+	cs-gpios = <&gpio4 24 0>, <&gpio4 26 0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi3>;
+	status = "okay";
+};
+
 &fec {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_enet>;
@@ -544,6 +552,16 @@
 				MX6QDL_PAD_EIM_D16__ECSPI1_SCLK		0x100b1
 				MX6QDL_PAD_EIM_EB2__GPIO2_IO30		0x80000000 /* CS0 */
 				MX6QDL_PAD_DISP0_DAT15__GPIO5_IO09	0x80000000 /* CS1 */
+			>;
+		};
+
+		pinctrl_ecspi3: ecspi3grp {
+			fsl,pins = <
+				MX6QDL_PAD_DISP0_DAT2__ECSPI3_MISO	0x100b1
+				MX6QDL_PAD_DISP0_DAT1__ECSPI3_MOSI	0x100b1
+				MX6QDL_PAD_DISP0_DAT0__ECSPI3_SCLK	0x100b1
+				MX6QDL_PAD_DISP0_DAT3__GPIO4_IO24	0x80000000 /* CS0 */
+				MX6QDL_PAD_DISP0_DAT5__GPIO4_IO26	0x80000000 /* CS2 */
 			>;
 		};
 


### PR DESCRIPTION
Add 'ecspi3' and 'spidev' devices to DTS to enable communication with LPC
